### PR TITLE
feat: canonical teams

### DIFF
--- a/data/teams.csv
+++ b/data/teams.csv
@@ -6,6 +6,11 @@ aws,Amazon
 apple,Apple
 boeing,Boeing
 bufbuild,Buf
+CanonicalLtd,Canonical
+canonical,Canonical
+canonical-web-and-design,Canonical
+charmed-kubernetes,Canonical
+ubuntu,Canonical
 cncf,Cloud Native Computing Foundation (CNCF)
 knative,Cloud Native Computing Foundation (CNCF)
 kubernetes,Cloud Native Computing Foundation (CNCF)


### PR DESCRIPTION
When collecting kubernetes releated projects, I found `charmed-kubernetes`.

It is certified by cncf but not donated to cncf. In case being forgotting, all canonical teams are pushed together with `charmed-kubernetes`.